### PR TITLE
login regex fix

### DIFF
--- a/packages/client/src/constants/formValidation/commonErrors.ts
+++ b/packages/client/src/constants/formValidation/commonErrors.ts
@@ -23,7 +23,9 @@ const noSpaces = (value: string) =>
   /^[^\s]*$/.test(value) ? true : CommonErrorMessages.noSpaces;
 
 const latinLetters = (value: string) =>
-  /^[a-zA-Z0-9_-\s]+$/.test(value) ? true : CommonErrorMessages.latinLetters;
+  /^[A-Za-z\d\s!@#$%^&*()-_=+[\]{}|;:'",.<>/?]*$/.test(value)
+    ? true
+    : CommonErrorMessages.latinLetters;
 
 const atLeastOneLetter = (value: string) =>
   /^.*[a-zA-Z]+.*$/.test(value) ? true : CommonErrorMessages.atLeastOneLetter;


### PR DESCRIPTION
### Какую задачу решаем
formValidation latinLetters не пропускала спецсимволы, а regex до этого не проверял, что все буквы латиница, поставил новый regex, немного сложный, но должен делать почти то, что просим


### Скриншоты/видяшка (если есть)

### TBD (если есть)